### PR TITLE
Fix caching, add new filter

### DIFF
--- a/src/app/components/leaderboard.tsx
+++ b/src/app/components/leaderboard.tsx
@@ -29,7 +29,9 @@ const tableCellStyles = 'px-6 block border-l-2 border-gray-200 leading-tight'
 
 export async function Leaderboard({ batches, graduatesOnly = false }: LeaderboardProps) {
   // First fetch all builders to get batch information
-  const buildersResponse = await fetch('https://buidlguidl-v3.ew.r.appspot.com/builders')
+  const buildersResponse = await fetch('https://buidlguidl-v3.ew.r.appspot.com/builders', {
+    cache: 'no-store', // Prevent caching
+  })
   const builders: BuilderData[] = await buildersResponse.json()
   
   // Create maps for batch number and graduate status
@@ -49,7 +51,9 @@ export async function Leaderboard({ batches, graduatesOnly = false }: Leaderboar
   })
   
   // Fetch leaderboard data
-  const response = await fetch('https://ethdevtechtree.buidlguidl.com/leaderboard')
+  const response = await fetch('https://ethdevtechtree.buidlguidl.com/leaderboard',{
+    cache: 'no-store', // Prevent caching
+  })
   const data: Data | null = await response.json()
 
   if (!response.ok || !data || data.leaderboard.length === 0) {

--- a/src/app/components/leaderboard.tsx
+++ b/src/app/components/leaderboard.tsx
@@ -190,7 +190,7 @@ export async function Leaderboard({ batches, graduatesOnly = false, builders }: 
                       <td className="py-2 whitespace-nowrap text-lg">
                         <span className={tableCellStyles}>
                           {leaderboardData.ens || leaderboardData.address}
-                          {isGraduate && ' 🎓'}
+                          {batches && isGraduate && ' 🎓'}
                         </span>
                       </td>
                       {showBatchColumn && (

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -17,9 +17,23 @@ export default async function LeaderboardPage({
   // Handle graduates filter
   const graduatesOnly = (await searchParams).graduates === 'true'
 
+  // Handle builder filter
+  const builderParam = (await searchParams).builder
+  const builders = Array.isArray(builderParam)
+    ? builderParam
+    : typeof builderParam === 'string' && builderParam.includes(',')
+    ? builderParam.split(',')
+    : builderParam
+    ? [builderParam]
+    : undefined
+
   return (
     <main>
-      <Leaderboard batches={batches} graduatesOnly={graduatesOnly} />
+      <Leaderboard 
+        batches={batches} 
+        graduatesOnly={graduatesOnly} 
+        builders={builders}
+      />
     </main>
   )
 } 


### PR DESCRIPTION
This PR explicitly sets the builder data and leaderboard data fetches to prevent caching. People want to see the leaderboard update when they complete challenges and the default nextjs caching on the fethc method makes it hard to do this.

This PR also adds a new way to filter the leaderboard by any set of builders with this query param structure:
```
?builder=0xrinat.eth&builder=0x92f444Fc0CDa9D47521fB1D53672c4c2898e2328&builder=vitalik.eth
```
or
```
?builder=0xrinat.eth,0x92f444Fc0CDa9D47521fB1D53672c4c2898e2328,vitalik.eth
```